### PR TITLE
✨ add script to interp. image to same grid as ref

### DIFF
--- a/scripts/interpolate_to_reference.py
+++ b/scripts/interpolate_to_reference.py
@@ -1,0 +1,16 @@
+import itk
+import typer
+from pathlib import Path
+
+from segmantic.prepro.core import resample_to_ref
+
+
+def main(input: Path, ref: Path, output: Path) -> None:
+    input_img = itk.imread(f"{input}")
+    ref_img = itk.imread(f"{ref}")
+    out_img = resample_to_ref(input_img, ref_img)
+    itk.imwrite(out_img, f"{output}")
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/src/segmantic/prepro/core.py
+++ b/src/segmantic/prepro/core.py
@@ -150,6 +150,33 @@ def resample(img: itkImage, target_spacing: Optional[Sequence] = None) -> itkIma
     return resampled
 
 
+def resample_to_ref(img: itkImage, ref: itkImage) -> itkImage:
+    """resample (2D/3D) image to a reference grid
+
+    Args:
+        img: input image
+        ref: reference image
+
+    Returns:
+        itkImage: resampled image
+    """
+    dim = img.GetImageDimension()
+    interpolator = itk.LinearInterpolateImageFunction.New(img)
+    transform = itk.IdentityTransform[itk.D, dim].New()
+
+    # resample to target resolution
+    resampled = itk.resample_image_filter(
+        img,
+        transform=transform,
+        interpolator=interpolator,
+        size=itk.size(ref),
+        output_spacing=itk.spacing(ref),
+        output_origin=itk.origin(ref),
+        output_direction=ref.GetDirection(),
+    )
+    return resampled
+
+
 def pad(
     img: AnyImage, target_size: Sequence[int] = (256, 256), value: float = 0
 ) -> AnyImage:


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
the PR adds a function and CLI to interpolate (resample) one image onto the grid of another

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #4 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

- no tests added
- run: `python scripts/interpolate_to_ref.py T1.nii.gz T2.nii.gz T1_onT2grid.nii.gz`
- output should have same dimensions, spacing and transform

## Checklist

- [x] Non-breaking change (fix or new feature that would not break existing functionality).

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] Unit tests for the changes and run locally with the command `pytest tests`
- [ ] Runs on minimum Python version
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
