### PR TITLE
✨ extend for 2d unet, run training with config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ cython_debug/
 
 # mkdoc outputs
 site
+
+
+# unversioned files
+unversioned/

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,5 +12,5 @@ disallow_untyped_defs = True
 
 # Thirdparties:
 
-[mypy-itk.*,PIL,matplotlib.*,torch,torchvision.*,numba,setuptools,pytest,typer.*,click,colorama,nibabel]
+[mypy-itk.*,PIL,matplotlib.*,torch,torchvision.*,numba,setuptools,pytest,typer.*,click,colorama,nibabel,sklearn.*]
 ignore_missing_imports = True

--- a/scripts/map_labels.py
+++ b/scripts/map_labels.py
@@ -4,7 +4,6 @@ import itk
 import typer
 import json
 from pathlib import Path
-from typing import Union
 
 import segmantic
 from segmantic.prepro.labels import (

--- a/scripts/run_monai_unet.py
+++ b/scripts/run_monai_unet.py
@@ -1,11 +1,14 @@
 from monai.config import print_config
 import os
+import json
 import typer
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from segmantic.prepro.labels import load_tissue_list
 from segmantic.seg import monai_unet
+
+app = typer.Typer()
 
 
 def get_nifti_files(dir: Path) -> List[Path]:
@@ -14,7 +17,8 @@ def get_nifti_files(dir: Path) -> List[Path]:
     return sorted([f for f in dir.glob("*.nii.gz")])
 
 
-def main(
+@app.command()
+def train(
     image_dir: Path = typer.Option(
         ..., "--image-dir", "-i", help="directory containing images"
     ),
@@ -25,14 +29,16 @@ def main(
         ..., "--tissue-list", "-t", help="label descriptors in iSEG format"
     ),
     results_dir: Path = typer.Option(
-        Path("results"), "--results-dir", "-r", help="output directory"
+        Path("results"),
+        "--results-dir",
+        "-r",
+        help="output directory where model checkpoints and logs are saved",
     ),
-    predict: bool = False,
     num_channels: int = 1,
     max_epochs: int = 600,
     gpu_ids: List[int] = [0],
 ):
-    """Train UNet or predict segmentation
+    """Train UNet
 
     Example invocation:
 
@@ -50,30 +56,57 @@ def main(
     log_dir = Path(results_dir) / "logs"
     model_file = Path(results_dir) / f"drcmr_{num_classes:d}.ckpt"
 
-    if predict:
-        monai_unet.predict(
-            model_file=model_file,
-            test_images=get_nifti_files(image_dir),
-            test_labels=get_nifti_files(labels_dir),
-            tissue_dict=tissue_dict,
-            output_dir=results_dir,
-            save_nifti=True,
-            gpu_ids=gpu_ids,
-        )
-    else:
-        monai_unet.train(
-            image_dir=image_dir,
-            labels_dir=labels_dir,
-            log_dir=log_dir,
-            num_classes=num_classes,
-            num_channels=num_channels,
-            model_file_name=model_file,
-            max_epochs=max_epochs,
-            output_dir=results_dir,
-            save_nifti=True,
-            gpu_ids=gpu_ids,
-        )
+    monai_unet.train(
+        image_dir=image_dir,
+        labels_dir=labels_dir,
+        log_dir=log_dir,
+        num_classes=num_classes,
+        num_channels=num_channels,
+        model_file_name=model_file,
+        max_epochs=max_epochs,
+        output_dir=results_dir,
+        save_nifti=True,
+        gpu_ids=gpu_ids,
+    )
+
+
+@app.command()
+def predict(
+    image_dir: Path = typer.Option(
+        ..., "--image-dir", "-i", help="directory containing images"
+    ),
+    labels_dir: Path = typer.Option(
+        None,
+        "--labels-dir",
+        "-l",
+        help="directory containing labelfields for performance evaluation",
+    ),
+    model_file: Path = typer.Option(..., "--model-file", "-m", help="saved checkpoint"),
+    tissue_list: Path = typer.Option(
+        ..., "--tissue-list", "-t", help="label descriptors in iSEG format"
+    ),
+    results_dir: Path = typer.Option(
+        Path("results"), "--results-dir", "-r", help="output directory"
+    ),
+    gpu_ids: List[int] = [0],
+):
+    """Predict segmentations
+
+    Example invocation:
+
+        -i ./dataset/images --results_dir ./results --tissue_list ./dataset/labels.txt
+    """
+
+    monai_unet.predict(
+        model_file=model_file,
+        test_images=get_nifti_files(image_dir),
+        test_labels=get_nifti_files(labels_dir),
+        tissue_dict=load_tissue_list(tissue_list),
+        output_dir=results_dir,
+        save_nifti=True,
+        gpu_ids=gpu_ids,
+    )
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    app()

--- a/scripts/run_monai_unet.py
+++ b/scripts/run_monai_unet.py
@@ -26,9 +26,11 @@ def train_config(
     """Train UNet with configuration provided as a json file
 
     Example invocation:
+
         --config-file my_config.json
 
     To generate a default config:
+
         --config-file my_config.json --print-defaults
     """
     if print_defaults:
@@ -73,6 +75,7 @@ def train(
     """Train UNet
 
     Example invocation:
+
         -i ./dataset/images -l ./dataset/labels --output-dir ./results --tissue_list ./dataset/labels.txt
     """
 
@@ -114,7 +117,7 @@ def predict(
 
     Example invocation:
 
-        -i ./dataset/images --results_dir ./results --tissue_list ./dataset/labels.txt
+        -i ./dataset/images -m model.ckpt --results-dir ./results --tissue-list ./dataset/labels.txt
     """
 
     monai_unet.predict(

--- a/src/segmantic/seg/dataset.py
+++ b/src/segmantic/seg/dataset.py
@@ -11,8 +11,8 @@ class DataSet(object):
     ):
         super().__init__()
 
-        image_files = sorted(image_dir.glob("*.nii.gz"))
-        label_files = sorted(labels_dir.glob("*.nii.gz"))
+        image_files = sorted(Path(image_dir).glob("*.nii.gz"))
+        label_files = sorted(Path(labels_dir).glob("*.nii.gz"))
         data_dicts = [
             {"image": image_name, "label": label_name}
             for image_name, label_name in zip(image_files, label_files)

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -11,11 +11,9 @@ from monai.transforms import (
     Orientationd,
     RandCropByLabelClassesd,
     RandFlipd,
-    RandAffined,
     NormalizeIntensityd,
     EnsureTyped,
     EnsureType,
-    Activationsd,
     SaveImaged,
     Invertd,
 )
@@ -25,8 +23,8 @@ from monai.metrics import DiceMetric, ConfusionMatrixMetric
 from monai.losses import DiceLoss
 from monai.inferers import sliding_window_inference
 from monai.data import CacheDataset, list_data_collate, decollate_batch, NiftiSaver
-from monai.config import print_config
 from monai.networks.utils import one_hot
+import numpy as np
 import torch
 import torch.utils.data
 import pytorch_lightning
@@ -69,7 +67,6 @@ class Net(pytorch_lightning.LightningModule):
         self.post_pred = Compose(
             [
                 EnsureType(),
-                # TODO: why argmax=True AND to_onehot=True?
                 AsDiscrete(argmax=True, to_onehot=True, n_classes=num_classes),
             ]
         )
@@ -139,6 +136,7 @@ class Net(pytorch_lightning.LightningModule):
                     spatial_size=spatial_size,
                     num_classes=self.num_classes,
                     num_samples=4,
+                    image_threshold=-np.inf,
                 )
             )
         return Compose(xforms + [EnsureTyped(keys=keys)])


### PR DESCRIPTION
## What do these changes do?

- the Unet code was extended for 2d input, i.e. transforms, spatial size etc
- moved create_transforms to the Net class, to reduce burden of adding new argument (CLI -> `train` -> `Net` -> `create_transforms `)
- the Unet CLI was split using [typer.app](https://typer.tiangolo.com/#an-example-with-two-subcommands) into different sub-commands: `train`, `predict` and `train-config`
- `train-config` calls the raw train function. The arguments are loaded from a config file. 
- a default config file can be generated from the function signature using the [inspect](https://docs.python.org/3/library/inspect.html#introspecting-callables-with-the-signature-object) module

## Related issue/s

None

## How to test

To create a config:
```
python scripts\run_monai_unet.py train-config -c foo.json --print-defaults
```
This generates a file `foo.json` that looks like e.g.:
```
{
    "image_dir": "<required option: Path>",
    "labels_dir": "<required option: Path>",
    "tissue_list": "<required option: Path>",
    "output_dir": "<required option: Path>",
    "num_channels": 1,
    "spatial_dims": 3,
    "spatial_size": null,
    "max_epochs": 600,
    "save_nifti": true,
    "gpu_ids": [0]
}
```
Now edit the configuration file and start training:
```
python scripts\run_monai_unet.py train-config -c foo.json
```

## Checklist

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Unit tests for the changes and run locally with the command `pytest tests`
- [x] Runs on minimum Python version
- [ ] Documentation reflects the changes
