### PR TITLE
✨use cmap from tissue list

### DIFF
--- a/src/segmantic/prepro/labels.py
+++ b/src/segmantic/prepro/labels.py
@@ -104,7 +104,7 @@ def load_tissue_list(file_name: Path) -> Dict[str, int]:
     return tissue_label_map
 
 
-def load_tissue_colors(file_name: Path) -> Dict[str, RGBTuple]:
+def load_tissue_colors(file_name: Path) -> Dict[int, RGBTuple]:
     """Load tissue colors from iSEG format tissue list
 
     Example file:
@@ -114,13 +114,12 @@ def load_tissue_colors(file_name: Path) -> Dict[str, RGBTuple]:
         C0.00 1.00 0.00 0.50 Fat
         C1.00 0.00 0.00 0.50 Skin
     """
-    tissue_color_map = {"Background": (0.0, 0.0, 0.0)}
+    tissue_idx = 0
+    tissue_color_map = {tissue_idx: (0.0, 0.0, 0.0)}
     with open(file_name) as f:
         for line in f.readlines():
             if line.startswith("C"):
                 rgba = [float(v.strip()) for v in line.lstrip("C").split(" ")[:-1]]
-                tissue = line.rsplit(" ", 1)[-1].rstrip()
-                if tissue in tissue_color_map:
-                    raise KeyError(f"duplicate label '{tissue}' found in '{file_name}'")
-                tissue_color_map[tissue] = (rgba[0], rgba[1], rgba[2])
+                tissue_idx += 1
+                tissue_color_map[tissue_idx] = (rgba[0], rgba[1], rgba[2])
     return tissue_color_map

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -41,7 +41,7 @@ from ..prepro.labels import load_tissue_list
 from .evaluation import confusion_matrix
 from .utils import make_device
 from .dataset import DataSet
-from .visualization import make_random_cmap, plot_confusion_matrix
+from .visualization import make_tissue_cmap, plot_confusion_matrix
 
 
 class Net(pytorch_lightning.LightningModule):
@@ -324,14 +324,14 @@ def train(
     net.eval()
     net.to(device)
     with torch.no_grad():
+        cmap = make_tissue_cmap(tissue_list)
+
         for i, val_data in enumerate(net.val_dataloader()):
             roi_size = (160, 160, 160)
             sw_batch_size = 4
             val_outputs = sliding_window_inference(
                 val_data["image"].to(device), roi_size, sw_batch_size, net
             )
-
-            cmap = make_random_cmap(num_classes + 1)
 
             plt.figure("check", (18, 6))
             for row, slice in enumerate([80, 180]):

--- a/src/segmantic/seg/visualization.py
+++ b/src/segmantic/seg/visualization.py
@@ -5,11 +5,21 @@ from matplotlib import colors
 import matplotlib.pyplot as plt
 from pathlib import Path
 import itertools
-from typing import List, Optional
+from typing import Dict, List, Optional
+from ..prepro.labels import load_tissue_colors
 
 
-# TODO: create color map from tissue list
-# from ..prepro.labels import RGBTuple, load_tissue_colors
+def make_tissue_cmap(tissue_list_file: Path):
+    """Make a color map for from an iSEG tissue list file"""
+    tissue_color_map = load_tissue_colors(tissue_list_file)
+    num_classes = max(tissue_color_map.keys()) + 1
+    col = np.zeros((num_classes, 3))
+    for idx, c in tissue_color_map.items():
+        r, g, b = c
+        col[idx, 0] = r
+        col[idx, 1] = g
+        col[idx, 2] = b
+    return colors.ListedColormap(col)
 
 
 def make_random_cmap(num_classes: int):

--- a/tests/prepro/test_labels.py
+++ b/tests/prepro/test_labels.py
@@ -23,7 +23,7 @@ def test_tissue_list_io(tmp_path: Path, tissue_map: dict):
 
     tissue_colors = labels.load_tissue_colors(file_path)
 
-    assert sorted(tissue_colors.keys()) == sorted(tissue_dict2.keys())
+    assert len(tissue_colors) == len(tissue_dict2)
 
 
 def test_build_tissue_map(tissue_map: dict):


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

Minor changes:
- change meaning of `load_tissue_colors`
- add `make_tissue_cmap` to plot segmentations using colors specified in tissue list files

## Related issue/s

None

## How to test

```
pytest tests
```

## Checklist

- [x] Breaking change: `load_tissue_colors` now returns `Dict[int, RGBTuple]`
- [x] Unit tests for the changes and run locally with the command `pytest tests`
- [ ] Runs on minimum Python version
- [ ] Documentation reflects the changes
