### PR TITLE
fix: PairedDataSet assumed pairs had exactly the same filename

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Format code

--- a/src/segmantic/seg/dataset.py
+++ b/src/segmantic/seg/dataset.py
@@ -8,29 +8,37 @@ class PairedDataSet(object):
         self,
         input_dir: Path = Path(""),
         input_key: str = "image",
+        input_glob: str = "*.nii.gz",
         output_dir: Path = Path(""),
         output_key: str = "label",
-        file_extension="*.nii.gz",
+        output_glob: str = "*.nii.gz",
         valid_split: float = 0.2,
         shuffle: bool = True,
         random_seed: int = None,
+        check_matching_filenames: bool = False,
         max_files: int = 0,
     ):
         super().__init__()
 
-        common_names: List[str] = []
-        output_files = [p.name for p in output_dir.glob(file_extension)]
-        for f in (p.name for p in input_dir.iterdir()):
-            if f in output_files:
-                common_names.append(f)
+        input_files = list(input_dir.glob(input_glob))
+        output_files = list(output_dir.glob(output_glob))
+        assert len(input_files) == len(output_files)
+
+        data_dicts = []
+        for i, o in zip(sorted(input_files), sorted(output_files)):
+            if check_matching_filenames:
+                istem = i.stem.replace(".nii", "").lower()
+                ostem = o.stem.replace(".nii", "").lower()
+                if not ((istem in ostem) or (ostem in istem)):
+                    raise RuntimeError(
+                        f"The pair image/label pair {i} : {o} doesn't correspond."
+                    )
+            data_dicts.append({input_key: i, output_key: o})
 
         if shuffle:
             my_random = random.Random(random_seed)
-            my_random.shuffle(common_names)
+            my_random.shuffle(data_dicts)
 
-        data_dicts = [
-            {input_key: input_dir / f, output_key: output_dir / f} for f in common_names
-        ]
         num_total = (
             len(data_dicts) if max_files == 0 else min(max_files, len(data_dicts))
         )

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -383,6 +383,7 @@ def train(
             val_outputs = sliding_window_inference(
                 val_data["image"].to(device), roi_size, sw_batch_size, net
             )
+            assert isinstance(val_outputs, torch.Tensor)
 
             plt.figure("check", (18, 6))
             for row, slice in enumerate([80, 180]):
@@ -521,6 +522,7 @@ def predict(
             val_pred = sliding_window_inference(
                 inputs=val_image, roi_size=(96, 96, 96), sw_batch_size=4, predictor=net
             )
+            assert isinstance(val_pred, torch.Tensor)
 
             test_data["pred"] = val_pred
             for i in decollate_batch(test_data):

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -282,6 +282,8 @@ def train(
     labels_dir: Path,
     tissue_list: Path,
     output_dir: Path,
+    image_glob: str = "*.nii.gz",
+    labels_glob: str = "*.nii.gz",
     checkpoint_file: Path = None,
     num_channels: int = 1,
     spatial_dims: int = 3,
@@ -319,7 +321,12 @@ def train(
             num_classes=num_classes,
             spatial_size=spatial_size,
         )
-    net.dataset = PairedDataSet(input_dir=image_dir, output_dir=labels_dir)
+    net.dataset = PairedDataSet(
+        input_dir=image_dir,
+        input_glob=image_glob,
+        output_dir=labels_dir,
+        output_glob=labels_glob,
+    )
     net.intensity_augmentation = augment_intensity
     net.spatial_augmentation = augment_spatial
     net.cache_rate = cache_rate


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

PairedDataSet assumed pairs had exactly the same filename.
- The PR reverts to use sorted files from two directory. 
- It complains if the number of files doesn't match
- a glob expression can be specified for image/labels to get e.g. all files matching `"*_T1w.nii.gz"`

<!-- Explain REVIEWERS what is this PR about -->


## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #4 : node_ports should have retry policies when upload/download fails  (FIXED)

-->


## How to test

Check it works for your dataset(s).

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->


## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] Unit tests for the changes and run locally with the command `pytest tests`
- [ ] Runs on minimum Python version
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
