### PR TITLE
💦 refine select best ensemble

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  precision: 2
+  range: 50...100
+  status:
+    project:
+      default:
+        threshold: 2%
+    patch:
+      default:
+        threshold: 20%
+    changes: false

--- a/.github/workflows/deploy_and_test.yml
+++ b/.github/workflows/deploy_and_test.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: segmantic_src
     - name: Setup python ${{ matrix.config.python-version }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,5 +9,5 @@ def labelfield() -> sitk.Image:
     """3D labelfield, where each XY slice has a uniform label = slice number"""
     image = make_image(shape=(5, 5, 5), spacing=(0.5, 0.6, 0.7))
     for i in range(5):
-        image[i, :, :] = i
+        image[..., i] = i
     return image

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -1,23 +1,10 @@
-from typing import Tuple
-
 import numpy as np
 import SimpleITK as sitk
 
 from segmantic.image import processing
-from segmantic.image.processing import make_image
 
 
-def test_image(shape: Tuple[int, ...] = (6, 4, 4)) -> sitk.Image:
-    data = np.zeros(shape)
-    for i in range(4):
-        data[i, ...] = i
-    img = sitk.GetImageFromArray(data)
-    img.SetSpacing((1.2, 1.3, 2.4))
-    return img
-
-
-def test_extract_slices() -> None:
-    labelfield = test_image()
+def test_extract_slices(labelfield: sitk.Image) -> None:
     slices_xy = processing.extract_slices(labelfield, axis=2)
 
     assert slices_xy[0].GetSpacing()[0] == labelfield.GetSpacing()[0]
@@ -29,7 +16,6 @@ def test_extract_slices() -> None:
 
 
 def test_pad_crop_center(labelfield: sitk.Image) -> None:
-    labelfield = test_image((5, 5, 5))
     padded = processing.pad(labelfield, target_size=(9, 9, 9))
     cropped = processing.crop_center(padded, target_size=(5, 5, 5))
 
@@ -44,13 +30,10 @@ def test_pad_crop_center(labelfield: sitk.Image) -> None:
     assert size[2] == 1
 
 
-def test_resample() -> None:
-    image = make_image(
-        shape=(3, 3), spacing=(2.0, 2.0), value=1.0, pixel_type=sitk.sitkFloat32
-    )
-    image[1, 1] = 0.0
+def test_resample(labelfield: sitk.Image) -> None:
+    # half the spacing
+    spacing = [s / 2.0 for s in labelfield.GetSpacing()]
+    res = processing.resample(labelfield, target_spacing=spacing)
 
-    # double the resolution from (2.0, 2.0) to (1.0, 1.0)
-    res = processing.resample(image, target_spacing=(1.0, 1.0))
-
-    assert list(res.GetSize()) == [2 * s for s in image.GetSize()]
+    # expecting double the resolution
+    assert list(res.GetSize()) == [2 * s for s in labelfield.GetSize()]

--- a/tests/seg/test_transforms.py
+++ b/tests/seg/test_transforms.py
@@ -1,10 +1,12 @@
 import torch
+from monai.networks import one_hot
 from torch.testing import assert_close
 
 from segmantic.seg.transforms import SelectBestEnsembled
 
 
 def test_SelectBestEnsembled():
+    # label (e.g. "argmax") data
     input = {
         "pred0": torch.ones(1, 3, 1, 1),
         "pred1": torch.tensor([2, 0, 2]).reshape(1, 3, 1, 1),
@@ -23,3 +25,19 @@ def test_SelectBestEnsembled():
     )
     result = tr(input)
     assert_close(result["output"], expected_value)
+
+    # One-Hot data
+    input = {k: one_hot(i, num_classes=3, dim=0) for k, i in input.items()}
+    expected_value = one_hot(expected_value, num_classes=3, dim=0)
+
+    tr = SelectBestEnsembled(
+        keys=["pred0", "pred1", "pred2"],
+        output_key="output",
+        label_model_dict={1: 0, 2: 1, 0: 2},
+    )
+    result = tr(input)
+    assert_close(result["output"], expected_value)
+
+
+if __name__ == "__main__":
+    test_SelectBestEnsembled()


### PR DESCRIPTION
## What do these changes do?

This PR extends the test for `SelectBestEnsembled` to one-hot input. It also changes the behavior: when the input is one-hot the output is also one-hot (similar to MeanEnsemble, i.e. you would need to add `AsDiscrete(argmax=True)` afterwards if you wanted argmax data. 