### PR TITLE
🐛 remove model parameters in predict

### DIFF
--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -760,7 +760,7 @@ def cross_validate(
 
     for config_file in Path(config_files_dir).iterdir():
         assert config_file.suffix in [".json", ".yml"], f"suffix: {config_file}"
-        is_json = config_file and config_file.suffix.lower() == ".json"
+        is_json = config_file.suffix.lower() == ".json"
         dumps = partial(config.dumps, is_json=is_json)
         loads = partial(config.loads, is_json=is_json)
 
@@ -818,9 +818,6 @@ def cross_validate(
                             test_images=test_images,
                             test_labels=test_labels,
                             tissue_dict=tissue_dict,
-                            # channels=current_layers,
-                            # strides=current_strides,
-                            dropout=0.0,
                             spacing=[1, 1, 1],
                             gpu_ids=gpu_ids,
                         )

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -565,9 +565,7 @@ def predict(
             settings = json.load(json_file)
         net: Net = Net.load_from_checkpoint(f"{model_file}", **settings)
     else:
-        net = Net.load_from_checkpoint(
-            f"{model_file}"
-        )
+        net = Net.load_from_checkpoint(f"{model_file}")
     num_classes = net.num_classes
 
     net.freeze()

--- a/src/segmantic/seg/monai_unet.py
+++ b/src/segmantic/seg/monai_unet.py
@@ -554,9 +554,6 @@ def predict(
     test_labels: Optional[list[Path]] = None,
     output_dir: Path = None,
     tissue_dict: dict[str, int] = None,
-    channels: tuple[int, ...] = (16, 32, 64, 128, 256),
-    strides: tuple[int, ...] = (2, 2, 2, 2),
-    dropout: float = 0.0,
     spacing: Sequence[float] = [],
     gpu_ids: list[int] = [],
 ) -> None:
@@ -569,7 +566,7 @@ def predict(
         net: Net = Net.load_from_checkpoint(f"{model_file}", **settings)
     else:
         net = Net.load_from_checkpoint(
-            f"{model_file}", channels=channels, strides=strides, dropout=dropout
+            f"{model_file}"
         )
     num_classes = net.num_classes
 


### PR DESCRIPTION
<!-- Common title prefixes/annotations:

WIP: work in progress

Consider prefix your PR message with an emoticon
  🐛 bugfix
  ✨ new feature
  ♻️ refactoring
  💄 updates UI or 🚸 UX/usability
  🚑️ hotfix
  ⚗️ experimental
  ⬆️ upgrades dependencies
  📝 documentation
or from https://gitmoji.dev/
-->

## What do these changes do?

<!-- Explain REVIEWERS what is this PR about -->
fixes predict when unet was trained with non-default parameters, e.g. channels.
- the channels are stored in the lightning model
- it was overriding these parameters when loading the state dict

## Related issue/s

<!-- Enumerate REVIEWERS other issues

e.g.

- #4 : node_ports should have retry policies when upload/download fails  (FIXED)

-->

## How to test

<!-- Give REVIEWERS some hits or code snippets on how could this be tested -->

## Checklist

<!-- This is YOUR section

Add here YOUR checklist/notes to guide and monitor the progress of the case!

e.g.

- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] Unit tests for the changes and run locally with the command `pytest tests`
- [ ] Runs on minimum Python version
- [ ] Documentation reflects the changes
- [ ] New module? Add your github username to [.github/CODEOWNERS](.github/CODEOWNERS)
-->
